### PR TITLE
Better specify cookiecutter version pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     author="Mendix Cloud Value Added Services Team",
     author_email="dis_valueaddedservices@mendix.com",
     packages=[],
-    install_requires=["cookiecutter<3"],
+    install_requires=["cookiecutter>2.1.1,<3"],
     extras_require={
         "lint": [
             "flake8<7",


### PR DESCRIPTION
According to Dependabot, versions before 2.1.1 had a security vulnerability.